### PR TITLE
Update default reallocateFn & loadModuleFn to match new wren 0.4.0 signatures

### DIFF
--- a/include/wrenbind17/vm.hpp
+++ b/include/wrenbind17/vm.hpp
@@ -75,6 +75,7 @@ namespace wrenbind17 {
             data->config.minHeapSize = minHeap;
             data->config.heapGrowthPercent = heapGrowth;
             data->config.userData = data.get();
+#if WREN_VERSION_NUMBER >= 4000 // >= 0.4.0
             data->config.reallocateFn = [](void* memory, size_t newSize, void* userData) -> void* { return std::realloc(memory, newSize); };
             data->config.loadModuleFn = [](WrenVM* vm, const char* name) -> WrenLoadModuleResult {
                 auto res = WrenLoadModuleResult();
@@ -83,22 +84,46 @@ namespace wrenbind17 {
                 const auto mod = self.modules.find(name);
                 if (mod != self.modules.end()) {
                     auto source = mod->second.str();
-                    char* buffer = new char[source.size() + 1];
-                    std::memcpy(static_cast<void*>(buffer), &source[0], source.size() + 1);
+                    auto buffer = new char[source.size() + 1];
+                    std::memcpy(buffer, &source[0], source.size() + 1);
                     res.source = buffer;
                     return res;
                 }
 
                 try {
                     auto source = self.loadFileFn(self.paths, std::string(name));
-                    char* buffer = new char[source.size() + 1];
-                    std::memcpy(static_cast<void*>(buffer), &source[0], source.size() + 1);
+                    auto buffer = new char[source.size() + 1];
+                    std::memcpy(buffer, &source[0], source.size() + 1);
                     res.source = buffer;
                 } catch (std::exception& e) {
                     (void)e;
                 }
                 return res;
             };
+#else // < 0.4.0
+            data->config.reallocateFn = std::realloc;
+            data->config.loadModuleFn = [](WrenVM* vm, const char* name) -> char* {
+                auto& self = *reinterpret_cast<VM::Data*>(wrenGetUserData(vm));
+
+                const auto mod = self.modules.find(name);
+                if (mod != self.modules.end()) {
+                    auto source = mod->second.str();
+                    auto buffer = new char[source.size() + 1];
+                    std::memcpy(buffer, &source[0], source.size() + 1);
+                    return buffer;
+                }
+
+                try {
+                    auto source = self.loadFileFn(self.paths, std::string(name));
+                    auto buffer = new char[source.size() + 1];
+                    std::memcpy(buffer, &source[0], source.size() + 1);
+                    return buffer;
+                } catch (std::exception& e) {
+                    (void)e;
+                    return nullptr;
+                }
+            };
+#endif // WREN_VERSION_NUMBER >= 4000
             data->config.bindForeignMethodFn = [](WrenVM* vm, const char* module, const char* className,
                                                   const bool isStatic, const char* signature) -> WrenForeignMethodFn {
                 auto& self = *reinterpret_cast<VM::Data*>(wrenGetUserData(vm));


### PR DESCRIPTION
Wren 0.4.0 is currently in pre-release. It introduces [two breaking API changes](https://github.com/wren-lang/wren/releases/tag/0.4.0-pre), this patch updates both of the affected default Wren VM config functions (`reallocateFn` & `loadModuleFn`.)

I have started using Wren 0.4.0 in my projects, however, perhaps we should wait until the full release before merging? Thank you for the wonderful library!