### PR TITLE
added simple install target to CMakeList

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,3 +61,12 @@ if(WRENBIND17_BUILD_TESTS)
     target_link_libraries(${PROJECT_NAME}_Tests PUBLIC ${PROJECT_NAME}_Coverage)
   endif()
 endif()
+
+# install headers
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/wrenbind17"
+  DESTINATION include
+  FILES_MATCHING
+  PATTERN "*.hxx"
+  PATTERN "*.hpp"
+  PATTERN "*.h"
+)


### PR DESCRIPTION
Hi, 
I would like to add this package to [conda-forge](https://conda-forge.org/ ).
It would simply things a lot to have an install target in the CMakeList  to install the headers with
`make install`

Greetings DerThorsten
