### PR TITLE
Add Support for M1 Macs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,7 @@
 [submodule "libs/Catch2"]
 	path = libs/Catch2
 	url = https://github.com/catchorg/Catch2.git
+	branch = v2.x
 [submodule "docs/themes/hugo-book"]
 	path = docs/themes/hugo-book
 	url = https://github.com/alex-shpak/hugo-book

--- a/include/wrenbind17/allocator.hpp
+++ b/include/wrenbind17/allocator.hpp
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <wren.hpp>
+
+#include <string>
+
 #include "index.hpp"
 #include "pop.hpp"
 #include "push.hpp"

--- a/include/wrenbind17/any.hpp
+++ b/include/wrenbind17/any.hpp
@@ -1,9 +1,11 @@
 #pragma once
 
+#include <typeinfo>
+#include <memory>
+
 #include "handle.hpp"
 #include "pop.hpp"
 #include "push.hpp"
-#include <typeinfo>
 
 /**
  * @ingroup wrenbind17

--- a/include/wrenbind17/caller.hpp
+++ b/include/wrenbind17/caller.hpp
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <wren.hpp>
+
+#include <memory>
+
 #include "index.hpp"
 #include "pop.hpp"
 #include "push.hpp"

--- a/include/wrenbind17/exception.hpp
+++ b/include/wrenbind17/exception.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <stdexcept>
+#include <memory>
+#include <string>
 
 /**
  * @ingroup wrenbind17

--- a/include/wrenbind17/foreign.hpp
+++ b/include/wrenbind17/foreign.hpp
@@ -1,10 +1,14 @@
 #pragma once
 
-#include "allocator.hpp"
-#include "caller.hpp"
+#include <wren.hpp>
+
 #include <iostream>
+#include <sstream>
 #include <ostream>
 #include <unordered_map>
+
+#include "allocator.hpp"
+#include "caller.hpp"
 
 /**
  * @ingroup wrenbind17

--- a/include/wrenbind17/handle.hpp
+++ b/include/wrenbind17/handle.hpp
@@ -1,7 +1,10 @@
 #pragma once
 
-#include <memory>
 #include <wren.hpp>
+
+#include <memory>
+
+#include "exception.hpp"
 
 /**
  * @ingroup wrenbind17

--- a/include/wrenbind17/index.hpp
+++ b/include/wrenbind17/index.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <memory>
+
 /**
  * @ingroup wrenbind17
  */

--- a/include/wrenbind17/method.hpp
+++ b/include/wrenbind17/method.hpp
@@ -1,6 +1,11 @@
 #pragma once
 
+#include <wren.hpp>
+
+#include <memory>
+
 #include "any.hpp"
+#include "exception.hpp"
 
 /**
  * @ingroup wrenbind17

--- a/include/wrenbind17/module.hpp
+++ b/include/wrenbind17/module.hpp
@@ -1,6 +1,12 @@
 #pragma once
 
+#include <wren.hpp>
+
+#include <vector>
+#include <string>
 #include <sstream>
+#include <unordered_map>
+
 #include "foreign.hpp"
 
 /**

--- a/include/wrenbind17/object.hpp
+++ b/include/wrenbind17/object.hpp
@@ -1,13 +1,15 @@
 #pragma once
 
-#include "exception.hpp"
-#include "handle.hpp"
+#include <wren.hpp>
+
 #include <cstdlib>
 #include <memory>
 #include <string>
 #include <typeinfo>
 #include <variant>
-#include <wren.hpp>
+
+#include "exception.hpp"
+#include "handle.hpp"
 
 /**
  * @ingroup wrenbind17

--- a/include/wrenbind17/pop.hpp
+++ b/include/wrenbind17/pop.hpp
@@ -1,5 +1,10 @@
 #pragma once
 
+#include <wren.hpp>
+
+#include <string>
+#include <memory>
+
 #include "object.hpp"
 
 namespace wrenbind17 {

--- a/include/wrenbind17/push.hpp
+++ b/include/wrenbind17/push.hpp
@@ -1,5 +1,10 @@
 #pragma once
 
+#include <wren.hpp>
+
+#include <string>
+
+#include "exception.hpp"
 #include "object.hpp"
 
 namespace wrenbind17 {

--- a/include/wrenbind17/std.hpp
+++ b/include/wrenbind17/std.hpp
@@ -1,10 +1,12 @@
 #pragma once
 
-#include "module.hpp"
+#include <algorithm>
 #include <list>
 #include <map>
 #include <unordered_map>
 #include <vector>
+
+#include "module.hpp"
 
 namespace wrenbind17 {
 #ifndef DOXYGEN_SHOULD_SKIP_THIS

--- a/include/wrenbind17/stddeque.hpp
+++ b/include/wrenbind17/stddeque.hpp
@@ -1,8 +1,11 @@
 #pragma once
 
+#include <wren.hpp>
+
+#include <deque>
+
 #include "pop.hpp"
 #include "push.hpp"
-#include <deque>
 
 namespace wrenbind17 {
 #ifndef DOXYGEN_SHOULD_SKIP_THIS

--- a/include/wrenbind17/stdlist.hpp
+++ b/include/wrenbind17/stdlist.hpp
@@ -1,8 +1,11 @@
 #pragma once
 
+#include <wren.hpp>
+
+#include <list>
+
 #include "pop.hpp"
 #include "push.hpp"
-#include <list>
 
 namespace wrenbind17 {
 #ifndef DOXYGEN_SHOULD_SKIP_THIS

--- a/include/wrenbind17/stdmap.hpp
+++ b/include/wrenbind17/stdmap.hpp
@@ -1,9 +1,12 @@
 #pragma once
 
-#include "pop.hpp"
-#include "push.hpp"
+#include <wren.hpp>
+
 #include <map>
 #include <unordered_map>
+
+#include "pop.hpp"
+#include "push.hpp"
 
 namespace wrenbind17 {
 #ifndef DOXYGEN_SHOULD_SKIP_THIS

--- a/include/wrenbind17/stdoptional.hpp
+++ b/include/wrenbind17/stdoptional.hpp
@@ -1,8 +1,11 @@
 #pragma once
 
+#include <wren.hpp>
+
+#include <optional>
+
 #include "pop.hpp"
 #include "push.hpp"
-#include <optional>
 
 namespace wrenbind17 {
 #ifndef DOXYGEN_SHOULD_SKIP_THIS

--- a/include/wrenbind17/stdset.hpp
+++ b/include/wrenbind17/stdset.hpp
@@ -1,9 +1,12 @@
 #pragma once
 
-#include "pop.hpp"
-#include "push.hpp"
+#include <wren.hpp>
+
 #include <set>
 #include <unordered_set>
+
+#include "pop.hpp"
+#include "push.hpp"
 
 namespace wrenbind17 {
 #ifndef DOXYGEN_SHOULD_SKIP_THIS

--- a/include/wrenbind17/stdvariant.hpp
+++ b/include/wrenbind17/stdvariant.hpp
@@ -1,8 +1,11 @@
 #pragma once
 
+#include <wren.hpp>
+
+#include <variant>
+
 #include "pop.hpp"
 #include "push.hpp"
-#include <variant>
 
 namespace wrenbind17 {
 #ifndef DOXYGEN_SHOULD_SKIP_THIS

--- a/include/wrenbind17/stdvector.hpp
+++ b/include/wrenbind17/stdvector.hpp
@@ -1,8 +1,11 @@
 #pragma once
 
+#include <wren.hpp>
+
+#include <vector>
+
 #include "pop.hpp"
 #include "push.hpp"
-#include <vector>
 
 namespace wrenbind17 {
 #ifndef DOXYGEN_SHOULD_SKIP_THIS

--- a/include/wrenbind17/variable.hpp
+++ b/include/wrenbind17/variable.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <memory>
+
+#include "exception.hpp"
 #include "method.hpp"
 #include "pop.hpp"
 #include "push.hpp"

--- a/include/wrenbind17/vm.hpp
+++ b/include/wrenbind17/vm.hpp
@@ -1,8 +1,9 @@
 #pragma once
 
-#include "map.hpp"
-#include "module.hpp"
-#include "variable.hpp"
+#include <wren.hpp>
+
+#include <iostream>
+#include <sstream>
 #include <cassert>
 #include <cstdlib>
 #include <cstring>
@@ -10,6 +11,12 @@
 #include <functional>
 #include <unordered_map>
 #include <vector>
+#include <memory>
+
+#include "exception.hpp"
+#include "map.hpp"
+#include "module.hpp"
+#include "variable.hpp"
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 namespace std {

--- a/tests/can_compile.cpp
+++ b/tests/can_compile.cpp
@@ -1,0 +1,3 @@
+// Make sure that just including wrenbind17 compiles
+
+#include <wrenbind17/wrenbind17.hpp>


### PR DESCRIPTION
While I was trying to run a project of mine on MacOS, I encountered some build errors from wrenbind17. They could be reproduced with the snippet below. The main problem was that each header was not self-sufficient and thus had missing includes on MacOS.

```cpp
// main.cpp (in the repository root)
#include <wrenbind17/wrenbind17.hpp>

int main() { return 0; }
```

Then running `clang main.cpp -I./libs/wren/src/include -I./include -std=c++17` resulted in the following beast:
<details>
<summary>Lengthy error message</summary>
<pre>
In file included from main.cpp:1:
In file included from ././include/wrenbind17/wrenbind17.hpp:8:
In file included from ././include/wrenbind17/std.hpp:3:
././include/wrenbind17/module.hpp:93:34: error: implicit instantiation of undefined template 'std::vector<std::string>'
        std::vector<std::string> raw;
                                 ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/iosfwd:259:28: note: template is declared here
class _LIBCPP_TEMPLATE_VIS vector;
                           ^
In file included from main.cpp:1:
In file included from ././include/wrenbind17/wrenbind17.hpp:8:
In file included from ././include/wrenbind17/std.hpp:3:
In file included from ././include/wrenbind17/module.hpp:4:
In file included from ././include/wrenbind17/foreign.hpp:7:
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/unordered_map:836:76: error: binding reference of type 'pair<...>' to value of type 'const pair<...>' drops 'const' qualifier
    pointer operator->() const {return pointer_traits<pointer>::pointer_to(__i_->__get_value());}
                                                                           ^~~~~~~~~~~~~~~~~~~
././include/wrenbind17/vm.hpp:88:38: note: in instantiation of member function 'std::__hash_map_iterator<std::__hash_iterator<std::__hash_node<std::__hash_value_type<std::string, wrenbind17::ForeignModule>, void *> *>>::operator->' requested here
                    auto source = mod->second.str();
                                     ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__memory/pointer_traits.h:153:67: note: passing argument to parameter '__r' here
                                      __nat, element_type>::type& __r) _NOEXCEPT
                                                                  ^
In file included from main.cpp:1:
In file included from ././include/wrenbind17/wrenbind17.hpp:8:
In file included from ././include/wrenbind17/std.hpp:3:
In file included from ././include/wrenbind17/module.hpp:4:
In file included from ././include/wrenbind17/foreign.hpp:7:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/unordered_map:437:
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__hash_table:2107:29: error: cannot initialize objectparameter of type 'std::__hash_node_base<std::__hash_node<std::__hash_value_type<std::string, wrenbind17::ForeignModule>, void *> *>' with an expression of type 'std::__hash_node<std::__hash_value_type<std::string, wrenbind17::ForeignModule>, void *>'
            __pn->__next_ = __h.get()->__ptr();
                            ^~~~~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__hash_table:1115:14: note: in instantiation of function template specialization 'std::__hash_table<std::__hash_value_type<std::string, wrenbind17::ForeignModule>, std::__unordered_map_hasher<std::string, std::__hash_value_type<std::string, wrenbind17::ForeignModule>, std::hash<std::string>, std::equal_to<std::string>, true>, std::__unordered_map_equal<std::string, std::__hash_value_type<std::string, wrenbind17::ForeignModule>, std::equal_to<std::string>, std::hash<std::string>, true>, std::allocator<std::__hash_value_type<std::string, wrenbind17::ForeignModule>>>::__emplace_unique_key_args<std::string, std::pair<std::string, wrenbind17::ForeignModule>>' requested here
      return __emplace_unique_key_args(__x.first, _VSTD::forward<_Pp>(__x));
             ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__hash_table:1079:14: note: in instantiation of function template specialization 'std::__hash_table<std::__hash_value_type<std::string, wrenbind17::ForeignModule>, std::__unordered_map_hasher<std::string, std::__hash_value_type<std::string, wrenbind17::ForeignModule>, std::hash<std::string>, std::equal_to<std::string>, true>, std::__unordered_map_equal<std::string, std::__hash_value_type<std::string, wrenbind17::ForeignModule>, std::equal_to<std::string>, std::hash<std::string>, true>, std::allocator<std::__hash_value_type<std::string, wrenbind17::ForeignModule>>>::__emplace_unique_extract_key<std::pair<std::string, wrenbind17::ForeignModule>>' requested here
      return __emplace_unique_extract_key(_VSTD::forward<_Pp>(__x),
             ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__hash_table:1137:14: note: in instantiation of function template specialization 'std::__hash_table<std::__hash_value_type<std::string, wrenbind17::ForeignModule>, std::__unordered_map_hasher<std::string, std::__hash_value_type<std::string, wrenbind17::ForeignModule>, std::hash<std::string>, std::equal_to<std::string>, true>, std::__unordered_map_equal<std::string, std::__hash_value_type<std::string, wrenbind17::ForeignModule>, std::equal_to<std::string>, std::hash<std::string>, true>, std::allocator<std::__hash_value_type<std::string, wrenbind17::ForeignModule>>>::__emplace_unique<std::pair<std::string, wrenbind17::ForeignModule>>' requested here
      return __emplace_unique(_VSTD::forward<_Pp>(__x));
             ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/unordered_map:1141:30: note: in instantiation of function template specialization 'std::__hash_table<std::__hash_value_type<std::string, wrenbind17::ForeignModule>, std::__unordered_map_hasher<std::string, std::__hash_value_type<std::string, wrenbind17::ForeignModule>, std::hash<std::string>, std::equal_to<std::string>, true>, std::__unordered_map_equal<std::string, std::__hash_value_type<std::string, wrenbind17::ForeignModule>, std::equal_to<std::string>, std::hash<std::string>, true>, std::allocator<std::__hash_value_type<std::string, wrenbind17::ForeignModule>>>::__insert_unique<std::pair<std::string, wrenbind17::ForeignModule>, void>' requested here
            {return __table_.__insert_unique(_VSTD::forward<_Pp>(__x));}
                             ^
././include/wrenbind17/vm.hpp:280:36: note: in instantiation of function template specialization 'std::unordered_map<std::string, wrenbind17::ForeignModule>::insert<std::pair<std::string, wrenbind17::ForeignModule>, void>' requested here
                it = data->modules.insert(std::make_pair(name, ForeignModule(name, data->vm.get()))).first;
                                   ^
In file included from main.cpp:1:
In file included from ././include/wrenbind17/wrenbind17.hpp:8:
In file included from ././include/wrenbind17/std.hpp:3:
In file included from ././include/wrenbind17/module.hpp:4:
In file included from ././include/wrenbind17/foreign.hpp:7:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/unordered_map:437:
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__hash_table:2112:23: error: cannot initialize objectparameter of type 'std::__hash_node_base<std::__hash_node<std::__hash_value_type<std::string, wrenbind17::ForeignModule>, void *> *>' with an expression of type 'std::__hash_node<std::__hash_value_type<std::string, wrenbind17::ForeignModule>, void *>'
                    = __h.get()->__ptr();
                      ^~~~~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__hash_table:2119:16: error: static_cast from 'std::unique_ptr<std::__hash_node<std::__hash_value_type<std::string, wrenbind17::ForeignModule>, void *>, std::__hash_node_destructor<std::allocator<std::__hash_node<std::__hash_value_type<std::string, wrenbind17::ForeignModule>, void *>>>>::pointer' (aka 'std::__hash_node<std::__hash_value_type<std::string, wrenbind17::ForeignModule>, void*> *') to 'std::__hash_table<std::__hash_value_type<std::string, wrenbind17::ForeignModule>, std::__unordered_map_hasher<std::string, std::__hash_value_type<std::string, wrenbind17::ForeignModule>, std::hash<std::string>, std::equal_to<std::string>, true>, std::__unordered_map_equal<std::string, std::__hash_value_type<std::string, wrenbind17::ForeignModule>, std::equal_to<std::string>, std::hash<std::string>, true>, std::allocator<std::__hash_value_type<std::string, wrenbind17::ForeignModule>>>::__next_pointer' (aka 'std::__hash_node_base<std::__hash_node<std::__hash_value_type<std::string, wrenbind17::ForeignModule>, void *> *> *'), which are not related by inheritance, is not allowed
        __nd = static_cast<__next_pointer>(__h.release());
               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
5 errors generated.
</pre>
</details>

Another issue was that the version of Catch2 used by wrenbind17's test suite did not support M1 macs. I've updated to the latest version which fixes the issue.

### Changes

- Added includes to all headers so they can compile on their own
- Added a test for this specific error (`can_compile.cpp`) so we can prevent it from re-appearing in the future.
- Updated the version of Catch2 for support of M1 macs