### PR TITLE
Standard compliant std::realloc

### DIFF
--- a/include/wrenbind17/vm.hpp
+++ b/include/wrenbind17/vm.hpp
@@ -114,6 +114,10 @@ namespace wrenbind17 {
 
 #if WREN_VERSION_NUMBER >= 4000 // >= 0.4.0
             data->config.reallocateFn = [](void* memory, size_t newSize, void* userData) -> void* {
+                if (newSize == 0) {
+                    std::free(memory);
+                    return nullptr;
+                }
                 return std::realloc(memory, newSize);
             };
             data->config.loadModuleFn = [](WrenVM* vm, const char* name) -> WrenLoadModuleResult {


### PR DESCRIPTION
Hi, I am Michael and I am using wrenbind17 (thanks for providing it). 
This is my first contribution to make it an even better library (others may follow ;-) ):

I noticed that std::realloc is called inside reallocateFn even if the size is 0.
According to C++ standard ( https://en.cppreference.com/w/cpp/memory/c/realloc ), 
the behavior in that case in implementation defined and its usage is discouraged.
Instead it is recommend to call std::free instead (which is also the default implementation inside wren).

Please find my merge request that improves the code in this regard.
Best regards
Michael